### PR TITLE
unwrap: fix --stream 1ms maxTime spill past the source block bound

### DIFF
--- a/stream_writer.go
+++ b/stream_writer.go
@@ -192,7 +192,10 @@ func streamSplitBlock(ctx context.Context, src *tsdb.Block, relabelConfig []*rel
 		}
 		slices.Sort(syms)
 		reader := &tenantBlockReader{src: src, refs: t.refs, keep: keep, symbols: syms}
-		id, werr := compactor.Write(outDir, reader, srcMeta.MinTime, srcMeta.MaxTime+1, nil)
+		// srcMeta.MaxTime is already an exclusive bound ([MinTime, MaxTime)) - passing
+		// MaxTime+1 here would spill the output meta 1ms past the source block and make
+		// contiguous outputs overlap (endless vertical compaction downstream).
+		id, werr := compactor.Write(outDir, reader, srcMeta.MinTime, srcMeta.MaxTime, nil)
 		if werr != nil {
 			return nil, fmt.Errorf("write tenant %s: %w", key, werr)
 		}

--- a/unwrap_test.go
+++ b/unwrap_test.go
@@ -422,6 +422,21 @@ func sameSummaries(a, b map[string]*tenantSum) bool {
 	return true
 }
 
+// assertWithinSource fails for any output block whose meta time range escapes
+// the source block's half-open [mint, maxt) range.
+func assertWithinSource(t *testing.T, outDir string, ids []ulid.ULID, mint, maxt int64) {
+	t.Helper()
+	for _, id := range ids {
+		meta, err := metadata.ReadFromDir(path.Join(outDir, id.String()))
+		if err != nil {
+			t.Fatalf("read meta %s: %v", id, err)
+		}
+		if meta.MinTime < mint || meta.MaxTime > maxt {
+			t.Errorf("block %s range [%d, %d) escapes source range [%d, %d)", id, meta.MinTime, meta.MaxTime, mint, maxt)
+		}
+	}
+}
+
 // TestStreamMatchesHead is the differential oracle for the streaming (no-Head)
 // writer: on the same source block it must produce per-tenant output identical to
 // the Head path - same blocks, series, sample counts and isolated ext-labels.
@@ -455,6 +470,7 @@ func TestStreamMatchesHead(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open block: %v", err)
 	}
+	srcBM := blk.Meta()
 	streamIDs, err := streamSplitBlock(context.Background(), blk, cfg, streamOut, origMeta, duration, logger)
 	blk.Close()
 	if err != nil {
@@ -469,6 +485,12 @@ func TestStreamMatchesHead(t *testing.T) {
 	if !sameSummaries(head, stream) {
 		t.Errorf("stream output differs from Head:\n head:   %v\n stream: %v", head, stream)
 	}
+	// Both paths must stay inside the source block's own half-open [MinTime,
+	// MaxTime) range: meta MaxTime is exclusive, so an output ending even 1ms
+	// past the source bound overlaps the next contiguous 2h block and feeds
+	// endless vertical compaction in a downstream Thanos compactor.
+	assertWithinSource(t, headOut, headIDs, srcBM.MinTime, srcBM.MaxTime)
+	assertWithinSource(t, streamOut, streamIDs, srcBM.MinTime, srcBM.MaxTime)
 	// value-level spot check: the 6000-float series and the transition series must
 	// be byte-faithful through the chunk copy.
 	if got := strings.Join(drainSeries(t, streamOut, streamIDs, `{prometheus="F"}`, `{__name__="disk"}`), ","); got != "f@0=1,f@1=2,h@2,h@3" {


### PR DESCRIPTION
`streamSplitBlock` passed `srcMeta.MaxTime+1` to `LeveledCompactor.Write`, which stamps mint/maxt into the output meta verbatim. `BlockMeta.MaxTime` is already an exclusive bound (`[MinTime, MaxTime)`), so every `--stream` output block ended 1 ms past its source block's range - the `+1` idiom is only correct in `BlockWriter.Flush`, where it applies to the inclusive last-sample timestamp.

With contiguous 2h-aligned sources (Mimir), consecutive per-tenant outputs overlap by 1 ms containing zero samples. A downstream Thanos compactor with vertical compaction enabled merges the pair, the merged block again ends 1 ms past a boundary, and the group rewrites one ever-growing block on every iteration (overlap compaction takes precedence and has no size cap). In our production this produced per-tenant blocks spanning 900+ hours at compaction level 443, rewritten ~12x/day across ~70 tenants, ~4-5 TB/day of compactor churn.

Fix: pass `srcMeta.MaxTime` as is. `TestStreamMatchesHead` now asserts both the Head and stream paths stay inside the source block's own `[MinTime, MaxTime)` range (it previously compared only series/sample counts, which is why the differential test missed this).
